### PR TITLE
This adds the option to display the x- and y-axis on the graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Making a pretty D3.js graph with a knockout binding.
 <div data-bind="d3LineGraph: observableArray"></div>
 ```
 
+To show the x and y axis on the graph enable it in the binding options:
+```html
+<div data-bind="d3LineGraph: { value: observableArray, showAxes: true }"></div>
+```
+
 Styling is handled with CSS.
 
 # Examples

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,6 +34,15 @@
              data-bind="d3LineGraph: example2"></div>
     </div>
 
+    <div class="exampleContainer">
+        <p>
+					This example renders the same observable array as in the first example
+					and has the x- and y-axis enabled.
+        </p>
+        <div id="Example2" class="example"
+						 data-bind="d3LineGraph: { value: example1, showAxes: true }"></div>
+    </div>
+
     <script src="examples.js"></script>
 
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,16 +36,16 @@
 
     <div class="exampleContainer">
         <p>
-					This example renders the same observable array as in the first example
-					and has the x- and y-axis enabled.
+            This example renders the same observable array as in the first example
+            and has the x- and y-axis enabled.
         </p>
-				<p>
-					Note that to style the graph instead of setting the background on the svg
-					element the fill of the rect.bg should be set, otherwise the background will
-					overlap with the axes.
-				</p>
+        <p>
+            Note that to style the graph instead of setting the background on the svg
+            element the fill of the rect.bg should be set, otherwise the background will
+            overlap with the axes.
+        </p>
         <div id="Example3" class="example"
-						 data-bind="d3LineGraph: { value: example1, showAxes: true }"></div>
+             data-bind="d3LineGraph: { value: example1, showAxes: true }"></div>
     </div>
 
     <script src="examples.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -39,7 +39,7 @@
 					This example renders the same observable array as in the first example
 					and has the x- and y-axis enabled.
         </p>
-        <div id="Example2" class="example"
+        <div id="Example3" class="example"
 						 data-bind="d3LineGraph: { value: example1, showAxes: true }"></div>
     </div>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -39,6 +39,11 @@
 					This example renders the same observable array as in the first example
 					and has the x- and y-axis enabled.
         </p>
+				<p>
+					Note that to style the graph instead of setting the background on the svg
+					element the fill of the rect.bg should be set, otherwise the background will
+					overlap with the axes.
+				</p>
         <div id="Example3" class="example"
 						 data-bind="d3LineGraph: { value: example1, showAxes: true }"></div>
     </div>

--- a/examples/style.css
+++ b/examples/style.css
@@ -38,6 +38,12 @@ button {
     border: 1px solid #000;
 }
 
+#Example3 svg .plot .bg {
+    background: #336699;
+		fill: #338800 !important;
+    border: 1px solid #000;
+}
+
 .path {
 	stroke: rgba(255,255,255,0.25);
     stroke-linejoin: round;

--- a/examples/style.css
+++ b/examples/style.css
@@ -41,7 +41,6 @@ button {
 #Example3 svg .plot .bg {
     background: #336699;
     fill: #338800 !important;
-    border: 1px solid #000;
 }
 
 .path {

--- a/examples/style.css
+++ b/examples/style.css
@@ -49,3 +49,9 @@ button {
     fill: rgba(255,255,255,0.10);
     stroke-width: 0;
 }
+
+.axis path,
+.axis line {
+		fill:none;
+		stroke:black;
+}

--- a/examples/style.css
+++ b/examples/style.css
@@ -40,15 +40,15 @@ button {
 
 #Example3 svg .plot .bg {
     background: #336699;
-		fill: #338800 !important;
+    fill: #338800 !important;
     border: 1px solid #000;
 }
 
 .path {
-	stroke: rgba(255,255,255,0.25);
+    stroke: rgba(255,255,255,0.25);
     stroke-linejoin: round;
-	stroke-width: 1.5;
-	fill: none;
+    stroke-width: 1.5;
+    fill: none;
 }
 
 .area {
@@ -58,6 +58,6 @@ button {
 
 .axis path,
 .axis line {
-		fill:none;
-		stroke:black;
+    fill:none;
+    stroke:black;
 }

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -51,9 +51,9 @@
 
             var plot = svg.append("g")
               .attr("class", "plot")
-              .attr("width", elementRect.width - padding.left - padding.right)
-              .attr("height", elementRect.height - padding.top - padding.bottom)
-              .attr("transform", "translate(" + padding.left + "," + padding.top + ")");
+              .attr("width", elementRect.width - padding.left - padding.right + 1)
+              .attr("height", elementRect.height - padding.top - padding.bottom + 1)
+              .attr("transform", "translate(" + (padding.left + 1) + "," + (padding.top - 1) + ")");
 
             plot.append("rect").attr("class", "bg").attr("width", elementRect.width - padding.left - padding.right)
               .attr("height", elementRect.height - padding.top - padding.bottom)

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -9,7 +9,7 @@
     }
 }(this, function (ko, d3) {
 
-    function getPaintingMethods(data, element) {
+    function getPaintingMethods(data, element, options) {
         var elementRect = element.getBoundingClientRect(),
             width = elementRect.width,
             height = elementRect.height,
@@ -23,17 +23,23 @@
             area: d3.svg.area().interpolate('basis')
                 .x(function (d, i) { return x(i); })
                 .y0(height)
-                .y1(function (d) { return y(d); })
+                .y1(function (d) { return y(d); }),
+					  scaleX: x,
+					  scaleY: y
         };
     }
 
 
     ko.bindingHandlers.d3LineGraph = {
-        init: function (element, valueAccessor) {
+        init: function (element, valueAccessor, allBindings) {
+						options = {};
+						ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
+						ko.utils.extend(options, allBindings.get('d3LineGraph'));
+
             var bindingContext = ko.utils.unwrapObservable(valueAccessor());
             var elementRect = element.getBoundingClientRect();
-            var data = bindingContext;
-            var shapes = getPaintingMethods(data, element);
+            var data = bindingContext.value();
+            var shapes = getPaintingMethods(data, element, options);
 
             var svg = d3.select(element).append('svg');
 
@@ -42,13 +48,59 @@
 
             svg.append('path').attr('class', 'area').attr('d', shapes.area(data));
             svg.append('path').attr('class', 'path').attr('d', shapes.line(data));
+
+						if(options.showAxes) {
+							var xAxis = d3.svg.axis()
+								.scale(shapes.scaleX)
+								.orient("bottom");
+
+							svg.append("g")
+								.attr("class", "x axis")
+								.call(xAxis);
+
+							var yAxis = d3.svg.axis()
+								.scale(shapes.scaleY)
+								.orient("left");
+
+							svg.append("g")
+								.attr("class", "y axis")
+								.attr("transform", "translate(40, 0)")
+								.call(yAxis);
+						}
         },
-        update: function (element, valueAccessor) {
+        update: function (element, valueAccessor, allBindings) {
+						options = {};
+						ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
+						ko.utils.extend(options, allBindings.get('d3LineGraph'));
             var bindingContext = ko.utils.unwrapObservable(valueAccessor());
-            var data = bindingContext;
-            var shapes = getPaintingMethods(data, element);
+            var data = bindingContext.value();
+            var shapes = getPaintingMethods(data, element, options);
 
             var svg = d3.select(element).select('svg');
+
+						if(options.showAxes) {
+							var xAxis = d3.svg.axis()
+								.scale(shapes.scaleX)
+								.orient("bottom");
+							
+							svg.select("g.x")
+								.interrupt()
+								.transition()
+								.ease('linear')
+								.duration(250)
+								.call(xAxis);
+
+							var yAxis = d3.svg.axis()
+								.scale(shapes.scaleY)
+								.orient("left");
+							
+							svg.select("g.y")
+								.interrupt()
+								.transition()
+								.ease('linear')
+								.duration(250)
+								.call(yAxis);
+						}
 
             svg.select('path.area')
                .interrupt()
@@ -63,7 +115,10 @@
                .ease('linear')
                .duration(250)
                .attr('d', shapes.line(data));
-        }
+        },
+				options: {
+									 showAxes: false
+								 }
     };
 
     return ko.bindingHandlers.d3LineGraph;

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -11,10 +11,11 @@
 
     function getPaintingMethods(data, element, options) {
         var elementRect = element.getBoundingClientRect(),
-            width = elementRect.width,
-            height = elementRect.height,
-            x = d3.scale.linear().domain([0, data.length - 1]).range([0, width]),
-            y = d3.scale.linear().domain([-1, d3.max(data) + 1]).range([height, 0]);
+						padding = options.padding(),
+            width = elementRect.width - padding.left - padding.right,
+            height = elementRect.height - padding.top - padding.bottom,
+            x = d3.scale.linear().domain([0, data.length-1]).range([0, width]),
+            y = d3.scale.linear().domain([-1, d3.max(data)+1]).range([height, 0]);
 
         return {
             line: d3.svg.line().interpolate('basis')
@@ -41,6 +42,7 @@
             var data = bindingContext.value
 							? bindingContext.value()
 							: bindingContext;
+						var padding = options.padding();
 
             var shapes = getPaintingMethods(data, element, options);
 
@@ -49,8 +51,14 @@
             svg.attr('width', elementRect.width)
                .attr('height', elementRect.height);
 
-            svg.append('path').attr('class', 'area').attr('d', shapes.area(data));
-            svg.append('path').attr('class', 'path').attr('d', shapes.line(data));
+						var plot = svg.append("g")
+							.attr("class", "plot")
+							.attr("width", elementRect.width - padding.left - padding.right)
+							.attr("height", elementRect.height - padding.top - padding.bottom)
+							.attr("transform", "translate(" + padding.left + "," + padding.top + ")");
+
+            plot.append('path').attr('class', 'area').attr('d', shapes.area(data));
+            plot.append('path').attr('class', 'path').attr('d', shapes.line(data));
 
 						if(options.showAxes) {
 							var xAxis = d3.svg.axis()
@@ -59,6 +67,7 @@
 
 							svg.append("g")
 								.attr("class", "x axis")
+								.attr("transform", "translate(" + padding.left + ","+(elementRect.height - padding.bottom)+")")
 								.call(xAxis);
 
 							var yAxis = d3.svg.axis()
@@ -67,7 +76,7 @@
 
 							svg.append("g")
 								.attr("class", "y axis")
-								.attr("transform", "translate(40, 0)")
+								.attr("transform", "translate(" + padding.left + "," + padding.top + ")")
 								.call(yAxis);
 						}
         },
@@ -122,7 +131,12 @@
                .attr('d', shapes.line(data));
         },
 				options: {
-									 showAxes: false
+									 showAxes: false,
+									 padding: function() {
+										 return this.showAxes
+										 	? { top: 15, right: 20, left: 40, bottom: 25 }
+										  : { top: 0, right: 0, left: 0, bottom: 0 }
+									 }
 								 }
     };
 

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -38,7 +38,10 @@
 
             var bindingContext = ko.utils.unwrapObservable(valueAccessor());
             var elementRect = element.getBoundingClientRect();
-            var data = bindingContext.value();
+            var data = bindingContext.value
+							? bindingContext.value()
+							: bindingContext;
+
             var shapes = getPaintingMethods(data, element, options);
 
             var svg = d3.select(element).append('svg');
@@ -73,7 +76,9 @@
 						ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
 						ko.utils.extend(options, allBindings.get('d3LineGraph'));
             var bindingContext = ko.utils.unwrapObservable(valueAccessor());
-            var data = bindingContext.value();
+            var data = bindingContext.value
+							? bindingContext.value()
+							: bindingContext;
             var shapes = getPaintingMethods(data, element, options);
 
             var svg = d3.select(element).select('svg');

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -57,6 +57,10 @@
 							.attr("height", elementRect.height - padding.top - padding.bottom)
 							.attr("transform", "translate(" + padding.left + "," + padding.top + ")");
 
+						plot.append("rect").attr("class", "bg").attr("width", elementRect.width - padding.left - padding.right)
+							.attr("height", elementRect.height - padding.top - padding.bottom)
+							.attr("fill", "none");
+							
             plot.append('path').attr('class', 'area').attr('d', shapes.area(data));
             plot.append('path').attr('class', 'path').attr('d', shapes.line(data));
 

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -11,11 +11,11 @@
 
     function getPaintingMethods(data, element, options) {
         var elementRect = element.getBoundingClientRect(),
-						padding = options.padding(),
+            padding = options.padding(),
             width = elementRect.width - padding.left - padding.right,
             height = elementRect.height - padding.top - padding.bottom,
-            x = d3.scale.linear().domain([0, data.length-1]).range([0, width]),
-            y = d3.scale.linear().domain([-1, d3.max(data)+1]).range([height, 0]);
+            x = d3.scale.linear().domain([0, data.length - 1]).range([0, width]),
+            y = d3.scale.linear().domain([-1, d3.max(data) + 1]).range([height, 0]);
 
         return {
             line: d3.svg.line().interpolate('basis')
@@ -25,24 +25,22 @@
                 .x(function (d, i) { return x(i); })
                 .y0(height)
                 .y1(function (d) { return y(d); }),
-					  scaleX: x,
-					  scaleY: y
+            scaleX: x,
+            scaleY: y
         };
     }
 
 
     ko.bindingHandlers.d3LineGraph = {
         init: function (element, valueAccessor, allBindings) {
-						options = {};
-						ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
-						ko.utils.extend(options, allBindings.get('d3LineGraph'));
+            var options = {};
+            ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
+            ko.utils.extend(options, allBindings.get('d3LineGraph'));
 
             var bindingContext = ko.utils.unwrapObservable(valueAccessor());
             var elementRect = element.getBoundingClientRect();
-            var data = bindingContext.value
-							? bindingContext.value()
-							: bindingContext;
-						var padding = options.padding();
+            var data = bindingContext.value ? bindingContext.value() : bindingContext;
+            var padding = options.padding();
 
             var shapes = getPaintingMethods(data, element, options);
 
@@ -51,74 +49,72 @@
             svg.attr('width', elementRect.width)
                .attr('height', elementRect.height);
 
-						var plot = svg.append("g")
-							.attr("class", "plot")
-							.attr("width", elementRect.width - padding.left - padding.right)
-							.attr("height", elementRect.height - padding.top - padding.bottom)
-							.attr("transform", "translate(" + padding.left + "," + padding.top + ")");
+            var plot = svg.append("g")
+              .attr("class", "plot")
+              .attr("width", elementRect.width - padding.left - padding.right)
+              .attr("height", elementRect.height - padding.top - padding.bottom)
+              .attr("transform", "translate(" + padding.left + "," + padding.top + ")");
 
-						plot.append("rect").attr("class", "bg").attr("width", elementRect.width - padding.left - padding.right)
-							.attr("height", elementRect.height - padding.top - padding.bottom)
-							.attr("fill", "none");
-							
+            plot.append("rect").attr("class", "bg").attr("width", elementRect.width - padding.left - padding.right)
+              .attr("height", elementRect.height - padding.top - padding.bottom)
+              .attr("fill", "none");
+
             plot.append('path').attr('class', 'area').attr('d', shapes.area(data));
             plot.append('path').attr('class', 'path').attr('d', shapes.line(data));
 
-						if(options.showAxes) {
-							var xAxis = d3.svg.axis()
-								.scale(shapes.scaleX)
-								.orient("bottom");
+            if (options.showAxes) {
+                var xAxis = d3.svg.axis()
+                  .scale(shapes.scaleX)
+                  .orient("bottom");
 
-							svg.append("g")
-								.attr("class", "x axis")
-								.attr("transform", "translate(" + padding.left + ","+(elementRect.height - padding.bottom)+")")
-								.call(xAxis);
+                svg.append("g")
+                  .attr("class", "x axis")
+                  .attr("transform", "translate(" + padding.left + "," + (elementRect.height - padding.bottom) + ")")
+                  .call(xAxis);
 
-							var yAxis = d3.svg.axis()
-								.scale(shapes.scaleY)
-								.orient("left");
+                var yAxis = d3.svg.axis()
+                  .scale(shapes.scaleY)
+                  .orient("left");
 
-							svg.append("g")
-								.attr("class", "y axis")
-								.attr("transform", "translate(" + padding.left + "," + padding.top + ")")
-								.call(yAxis);
-						}
+                svg.append("g")
+                  .attr("class", "y axis")
+                  .attr("transform", "translate(" + padding.left + "," + padding.top + ")")
+                  .call(yAxis);
+            }
         },
         update: function (element, valueAccessor, allBindings) {
-						options = {};
-						ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
-						ko.utils.extend(options, allBindings.get('d3LineGraph'));
+            var options = {};
+            ko.utils.extend(options, ko.bindingHandlers.d3LineGraph.options);
+            ko.utils.extend(options, allBindings.get('d3LineGraph'));
             var bindingContext = ko.utils.unwrapObservable(valueAccessor());
-            var data = bindingContext.value
-							? bindingContext.value()
-							: bindingContext;
+            var data = bindingContext.value ? bindingContext.value() : bindingContext;
             var shapes = getPaintingMethods(data, element, options);
 
             var svg = d3.select(element).select('svg');
 
-						if(options.showAxes) {
-							var xAxis = d3.svg.axis()
-								.scale(shapes.scaleX)
-								.orient("bottom");
-							
-							svg.select("g.x")
-								.interrupt()
-								.transition()
-								.ease('linear')
-								.duration(250)
-								.call(xAxis);
+            if (options.showAxes) {
+                var xAxis = d3.svg.axis()
+                  .scale(shapes.scaleX)
+                  .orient("bottom");
 
-							var yAxis = d3.svg.axis()
-								.scale(shapes.scaleY)
-								.orient("left");
-							
-							svg.select("g.y")
-								.interrupt()
-								.transition()
-								.ease('linear')
-								.duration(250)
-								.call(yAxis);
-						}
+                svg.select("g.x")
+                  .interrupt()
+                  .transition()
+                  .ease('linear')
+                  .duration(250)
+                  .call(xAxis);
+
+                var yAxis = d3.svg.axis()
+                  .scale(shapes.scaleY)
+                  .orient("left");
+
+                svg.select("g.y")
+                  .interrupt()
+                  .transition()
+                  .ease('linear')
+                  .duration(250)
+                  .call(yAxis);
+            }
 
             svg.select('path.area')
                .interrupt()
@@ -134,16 +130,13 @@
                .duration(250)
                .attr('d', shapes.line(data));
         },
-				options: {
-									 showAxes: false,
-									 padding: function() {
-										 return this.showAxes
-										 	? { top: 15, right: 20, left: 40, bottom: 25 }
-										  : { top: 0, right: 0, left: 0, bottom: 0 }
-									 }
-								 }
+        options: {
+                   showAxes: false,
+                   padding: function () {
+                       return this.showAxes ? { top: 15, right: 20, left: 40, bottom: 25 } : { top: 0, right: 0, left: 0, bottom: 0 };
+                   }
+                 }
     };
 
     return ko.bindingHandlers.d3LineGraph;
-
 }));


### PR DESCRIPTION
While looking for a way to use Knockout in combination with the D3 library I came across your binding which works like a charm. However I want to display the x- and y-axis on my graph so I thought to add it to the binding.
Currently the rendering of the axes is still within the graph itself, I'll see if I can make it a bit more pretty.
