### PR TITLE
This adds the option to bind to complex data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,70 @@ Making a pretty D3.js graph with a knockout binding.
 <div data-bind="d3LineGraph: observableArray"></div>
 ```
 
+## Complex values
+To use data objects with the binding, specify how the binding should access the x/y values:
+
+```js
+var data = [
+    { pos: 0, value: 1 },
+    { pos: 1, value: 3 },
+    { pos: 2, value: 4 },
+    { pos: 4, value: 5 }
+];
+```
+
+```html
+<div data-bind="d3LineGraph: { 
+    value: observableArray, 
+    y: function(d) { return d.value; }, 
+    x: function(d, index) { return d.pos; } 
+    }">
+</div>
+```
+The x accessor is optional, if not specified it will use the index of the element as the x-position.
+
+## Axis and formatting
 To show the x and y axis on the graph enable it in the binding options:
+
 ```html
 <div data-bind="d3LineGraph: { value: observableArray, showAxes: true }"></div>
 ```
 
-Styling is handled with CSS.
+### Axis scale options
+The scale used for the axis can be specified using the binding options, any d3 scaling function can be used:
+
+```html
+<div data-bind="d3LineGraph: { 
+    value: observableArray, 
+    yScale: d3.time.scale, 
+    xScale: d3.scale.linear 
+    }">
+</div>
+```
+By default the binding will use the linear scale. Note that specifying a different scale than linear implies using a complex data source so be sure to also specify the x & y accessors.
+
+### Setting additional axis options
+It may be required to set additional options on the axis. This can be done using a callback specified in the binding options. 
+For example setting the format of a time scale axis:
+
+```js
+function xAxisFormatCallback(axis) {
+    axis.tickFormat(d3.time.format("%d %H:%M"));
+}
+```
+
+```html
+<div data-bind="d3LineGraph: { 
+    value: observableArray, 
+    xScale: d3.time.scale, 
+    xAxisOptions: xAxisFormatCallback 
+    }">
+</div>
+```
+When the graph is rendered the callback will be invoked and additional options included.
+
+# Graph styling
+Styling is handled with CSS, see the example for more details.
 
 # Examples
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "knockout-d3-line-graph",
+  "version": "1.0.0",
+  "main": "lib/knockout-d3-line-graph.js",
+  "license": "BSD 3-Clause",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "examples",
+    "vendor",
+    "Gruntfile.js",
+    "package.json"
+  ],
+  "dependencies": {
+    "knockoutjs": "~3.2.0",
+    "d3": "=3.4.4"
+  },
+  "authors": [
+    "Gustav Nikolaj Olsen <gustavnikolaj@gmail.com>"
+  ]
+}

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -9,11 +9,22 @@ function ViewModel() {
             randomNumber = Math.random() * (max - min) + min;
 
         that.example1.push(randomNumber);
+        that.complexData.push({ position: new Date(2015, 1, that.complexData().length + 1), value: randomNumber });
     };
 
     this.example2 = ko.computed(function () {
         return that.example1().slice(-10);
     });
+
+    this.complexData = ko.observableArray([
+        { position: new Date(2015, 1, 1), value: 10 },
+        { position: new Date(2015, 1, 2), value: 8 },
+        { position: new Date(2015, 1, 3), value: 12 },
+        { position: new Date(2015, 1, 4), value: 13 },
+        { position: new Date(2015, 1, 5), value: 11 },
+        { position: new Date(2015, 1, 6), value: 7 },
+        { position: new Date(2015, 1, 7), value: 5 }
+    ]);
 }
 
 var viewModel = new ViewModel();

--- a/examples/index.html
+++ b/examples/index.html
@@ -48,6 +48,27 @@
              data-bind="d3LineGraph: { value: example1, showAxes: true }"></div>
     </div>
 
+    <div class="exampleContainer">
+        <p>
+            This example demonstrates binding to complex data where the binding needs to be
+            told how to get the x- and y-value. The data type looks like:
+        </p>
+        <pre>
+            { position: new Date(2015, 1, 1), value: 11 }
+        </pre>
+        <div id="Example4" 
+             class="example"
+             data-bind="d3LineGraph: { 
+                value: complexData,
+                showAxes: true, 
+                xScale: d3.time.scale, 
+                x: function (d, i) { return d.position; },
+                y: function (d) { return d.value; },
+                xAxisOptions: function (axis) { axis.tickFormat(d3.time.format('%d')); }
+            }">
+        </div>
+    </div>
+
     <script src="examples.js"></script>
 
 </body>

--- a/examples/style.css
+++ b/examples/style.css
@@ -43,6 +43,11 @@ button {
     fill: #338800 !important;
 }
 
+#Example4 svg .plot .bg {
+    background: #336699;
+    fill: #338800 !important;
+}
+
 .path {
     stroke: rgba(255,255,255,0.25);
     stroke-linejoin: round;

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -139,8 +139,8 @@
                    padding: function () {
                        return this.showAxes ? { top: 15, right: 20, left: 40, bottom: 25 } : { top: 0, right: 0, left: 0, bottom: 0 };
                    },
-                   x: function (d) { return d; },
-                   y: function (d, i) { return i; },
+                   x: function (d, i) { return i; },
+                   y: function (d) { return d; },
                    xScale: d3.scale.linear,
                    yScale: d3.scale.linear,
                    xAxisOptions: function (axis) { },

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -14,19 +14,19 @@
             padding = options.padding(),
             width = elementRect.width - padding.left - padding.right,
             height = elementRect.height - padding.top - padding.bottom,
-            x = d3.scale.linear().domain([0, data.length - 1]).range([0, width]),
-            y = d3.scale.linear().domain([-1, d3.max(data) + 1]).range([height, 0]);
+            scalerX = options.xScale().domain(d3.extent(data, options.x)).range([0, width]),
+            scalerY = options.yScale().domain(d3.extent(data, options.y)).range([height, 0]);
 
         return {
             line: d3.svg.line().interpolate('basis')
-                .x(function (d, i) { return x(i); })
-                .y(function (d) { return y(d); }),
+                .x(function (d, i) { return scalerX(options.x(d, i)); })
+                .y(function (d) { return scalerY(options.y(d));; }),
             area: d3.svg.area().interpolate('basis')
-                .x(function (d, i) { return x(i); })
+                .x(function (d, i) { return scalerX(options.x(d, i)); })
                 .y0(height)
-                .y1(function (d) { return y(d); }),
-            scaleX: x,
-            scaleY: y
+                .y1(function (d) { return scalerY(options.y(d)); }),
+            scaleX: scalerX,
+            scaleY: scalerY
         };
     }
 
@@ -97,6 +97,8 @@
                   .scale(shapes.scaleX)
                   .orient("bottom");
 
+                options.xAxisOptions(xAxis);
+
                 svg.select("g.x")
                   .interrupt()
                   .transition()
@@ -107,6 +109,8 @@
                 var yAxis = d3.svg.axis()
                   .scale(shapes.scaleY)
                   .orient("left");
+
+                options.yAxisOptions(yAxis);
 
                 svg.select("g.y")
                   .interrupt()

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -20,7 +20,7 @@
         return {
             line: d3.svg.line().interpolate('basis')
                 .x(function (d, i) { return scalerX(options.x(d, i)); })
-                .y(function (d) { return scalerY(options.y(d));; }),
+                .y(function (d) { return scalerY(options.y(d)); }),
             area: d3.svg.area().interpolate('basis')
                 .x(function (d, i) { return scalerX(options.x(d, i)); })
                 .y0(height)

--- a/lib/knockout-d3-line-graph.js
+++ b/lib/knockout-d3-line-graph.js
@@ -134,7 +134,14 @@
                    showAxes: false,
                    padding: function () {
                        return this.showAxes ? { top: 15, right: 20, left: 40, bottom: 25 } : { top: 0, right: 0, left: 0, bottom: 0 };
-                   }
+                   },
+                   x: function (d) { return d; },
+                   y: function (d, i) { return i; },
+                   xScale: d3.scale.linear,
+                   yScale: d3.scale.linear,
+                   xAxisOptions: function (axis) { },
+                   yAxisOptions: function (axis) { }
+
                  }
     };
 


### PR DESCRIPTION
Following up on the previous feature to show the axis, I wanted to be able to support data types in the viewmodel where the x/y positions are retrieved from properties on the data instead of inferred from the position in the array.
This also adds the ability to specify a different scale for the axis (for example the time scale) and to specify additional options for the axis.

I've run JSLint and have done a quick search for tabs (one tries to learn ;-) but I welcome your feedback!
